### PR TITLE
Changx Topic Arn to send msg to using Pub Package.

### DIFF
--- a/pub/pub.go
+++ b/pub/pub.go
@@ -34,6 +34,12 @@ func (s *SNSPublisher[T]) WithLogger(logger zerolog.Logger) *SNSPublisher[T] {
 	return s
 }
 
+// WithNewSnsTopicArn sets a new SNS topic ARN for publishing events.
+func (s *SNSPublisher[T]) WithNewSnsTopicArn(topicArn string) *SNSPublisher[T] {
+	s.topicArn = topicArn
+	return s
+}
+
 // marshalProtoMutationEventToJSON marshals a ProtoMutationEvent with proto.Message fields to JSON.
 func marshalProtoMutationEventToJSON[T proto.Message](e models.ProtoMutationEvent[T]) ([]byte, error) {
 	beforeBytes, err := protojson.Marshal(e.Before)


### PR DESCRIPTION
this PR adds a new  `WithNewSnsTopicArn` method that user can use to switch topic arn when calling `published` method. this is particularly useful when implementing the annotation service in the api since we’ll have both notes arns and bookmarks arns all in one service so after initializing the `NewPubService()` with want to be able to switch when publishing messages to notes or bookmarks topics.